### PR TITLE
added simple integration test

### DIFF
--- a/src/Core/NeoClient.php
+++ b/src/Core/NeoClient.php
@@ -4,7 +4,9 @@ use Neoxygen\NeoClient\ClientBuilder;
 
 class NeoClient implements TransactionalManager{
 
-	
+    /**
+     * @var \Neoxygen\NeoClient\Client
+     */
 	protected $client = null;
 
 	/**
@@ -99,6 +101,14 @@ class NeoClient implements TransactionalManager{
 		$this->relationshipStatements[] = $statement;
 
 	}
+
+    /**
+     * @return \Neoxygen\NeoClient\Client
+     */
+	public function getClient()
+    {
+        return $this->client;
+    }
 
 	protected function getNodeStatements(){
 

--- a/tests/Integration/Domain/GithubUser.php
+++ b/tests/Integration/Domain/GithubUser.php
@@ -1,16 +1,24 @@
 <?php
 
-namespace Models;
+namespace Tests\Integration\Domain;
 
 use Annotations\Node;
 use Annotations\GraphProperty;
 use Annotations\Entity as GraphEntity;
+use Annotations\Id;
 
 /**
  * @Node(labels = {"GithubUser"})
  * @GraphEntity
  */
-class GithubUser extends Entity{
+class GithubUser
+{
+
+    /**
+     * @Id
+     * @var int
+     */
+    protected $id;
 
     /**
      * @GraphProperty(type="string", key="userName")
@@ -30,6 +38,14 @@ class GithubUser extends Entity{
     {
         $this->userName = $userName;
         $this->realName = $realName;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
     }
 
     /**

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Integration;
+
+use Core\NeoClient;
+use Meta\ReflectionClass;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Core\UnitOfWork;
+use Meta\MetadataFactory;
+
+class IntegrationTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Faker\Generator
+     */
+    protected $faker;
+
+    /**
+     * @var \Core\UnitOfWork
+     */
+    protected $uow;
+
+    public function setUp()
+    {
+        $this->faker = \Faker\Factory::create();
+        $credentials['connection'] = 'http';
+        $credentials['host'] = 'localhost';
+        $credentials['port'] = 7474;
+        $credentials['username'] = 'neo4j';
+        $credentials['password'] = '123123';
+
+        $reflector = new ReflectionClass(new AnnotationReader(), new AnnotationRegistry());
+        $this->uow = new UnitOfWork(
+            new NeoClient($credentials), new MetadataFactory($reflector)
+        );
+    }
+
+    /**
+     * @return \Neoxygen\NeoClient\Client
+     */
+    protected function getClient()
+    {
+        return $this->uow->getManager()->getClient();
+    }
+}

--- a/tests/Integration/UseCases/SimpleUseCaseTest.php
+++ b/tests/Integration/UseCases/SimpleUseCaseTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Integration\UseCases;
+
+use Tests\Integration\IntegrationTestCase;
+use Models\GithubUser;
+
+/**
+ * @group integration
+ * @group test-case
+ */
+class SimpleUseCaseTest extends IntegrationTestCase
+{
+    public function testSimpleEntityCase()
+    {
+        $user = new GithubUser('ikwattro', 'Christophe Willemsen');
+        $this->uow->persist($user);
+        $this->uow->commit();
+
+        $q = 'MATCH (n:GithubUser {userName: {userName}}) RETURN n';
+        $result = $this->getClient()->sendCypherQuery($q, ['userName' => $user->getUserName()])->getResult();
+        $n = $result->get('n');
+
+        $this->assertNotNull($n);
+    }
+}

--- a/tests/Models/Entity.php
+++ b/tests/Models/Entity.php
@@ -1,5 +1,7 @@
-<?php 
+<?php
+
 namespace Models;
+
 use Annotations\Id;
 
 abstract class Entity{
@@ -7,14 +9,16 @@ abstract class Entity{
 	/**
 	 * @Id
 	 * 
-	 * @var Core\Id
+	 * @var \Core\Id
 	 */
-	protected $id = null;	
+	protected $id = null;
 
+    /**
+     * @return \Core\Id
+     */
 	public function getId(){
 
 		return $this->id;
 
 	}
-
 }

--- a/tests/Models/GithubUser.php
+++ b/tests/Models/GithubUser.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Models;
+
+use Annotations\Node;
+use Annotations\GraphProperty;
+use Annotations\Entity as GraphEntity;
+
+/**
+ * @Node(labels = {"GithubUser"})
+ * @GraphEntity
+ */
+class GithubUser extends Entity{
+
+    /**
+     * @GraphProperty(type="string", key="userName")
+     */
+    protected $userName;
+
+    /**
+     * @GraphProperty(type="string", key="userName")
+     */
+    protected $realName;
+
+    /**
+     * @param string $userName
+     * @param string $realName
+     */
+    public function __construct($userName, $realName)
+    {
+        $this->userName = $userName;
+        $this->realName = $realName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserName()
+    {
+        return $this->userName;
+    }
+
+    /**
+     * @param string $userName
+     */
+    public function setUserName($userName)
+    {
+        $this->userName = $userName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRealName()
+    {
+        return $this->realName;
+    }
+
+    /**
+     * @param string $realName
+     */
+    public function setRealName($realName)
+    {
+        $this->realName = $realName;
+    }
+}

--- a/tests/Models/GithubUser.php
+++ b/tests/Models/GithubUser.php
@@ -18,7 +18,7 @@ class GithubUser extends Entity{
     protected $userName;
 
     /**
-     * @GraphProperty(type="string", key="userName")
+     * @GraphProperty(type="string", key="realName")
      */
     protected $realName;
 


### PR DESCRIPTION
Hi m8,

I did a simple use case test, I think this is the real basis.

Some points : 

* The key annotation property of GraphProperty is mandatory, why ?
* If I have to keys with the same value, no exception is thrown.

```
/**
	 * @RelateTo(type = "HAS_USERNAME", reference = "Models\EmailAddress")
	 * @GraphProperty(type = "string", key = "username")
	 * @var Models\EmailAddress
	 */
	protected $username = null;
```
This is completely unclear to me. IMO `or` it should be a relationship, `or` a property but not both. If you have a good reason, please explain.

Will make more commits soon.